### PR TITLE
Explicit arr object creation

### DIFF
--- a/python/source/io.rst
+++ b/python/source/io.rst
@@ -21,6 +21,11 @@ Given an array with 100 numbers, from 0 to 99
 
 .. testcode::
 
+    import numpy as np
+    import pyarrow as pa
+
+    arr = pa.array(np.arange(100))
+
     print(f"{arr[0]} .. {arr[-1]}")
 
 .. testoutput::
@@ -121,6 +126,11 @@ the Arrow IPC format.
 Given an array with 100 numbers, from 0 to 99
 
 .. testcode::
+
+    import numpy as np
+    import pyarrow as pa
+
+    arr = pa.array(np.arange(100))
 
     print(f"{arr[0]} .. {arr[-1]}")
 
@@ -371,6 +381,11 @@ Write a Feather file
 Given an array with 100 numbers, from 0 to 99
 
 .. testcode::
+
+    import numpy as np
+    import pyarrow as pa
+
+    arr = pa.array(np.arange(100))
 
     print(f"{arr[0]} .. {arr[-1]}")
 


### PR DESCRIPTION
Hi, I have started playing with the cookbook examples and there is a little doc section that I did not find clear hence here this PR.

### Issue
The **testsetup::** blocs in the rst files are not written out in the resulting HTML.
In the "Given an array with 100 numbers, from 0 to 99" sections the **arr** object pops up ex nihilo in the documentation which might lose the reader a bit even though most people will guess the np.arange here.

### Proposed solution
Add the array creation code in the testcode:: blocs for those sections section to make it more explicit.

That is going from
```
Given an array with 100 numbers, from 0 to 99

print(f"{arr[0]} .. {arr[-1]}")

0 .. 99
```

to

```
Given an array with 100 numbers, from 0 to 99

import numpy as np
import pyarrow as pa

arr = pa.array(np.arange(100))

print(f"{arr[0]} .. {arr[-1]}")

0 .. 99
```
in the resulting HTML.


Thanks,
Nathanaël
