### PR TITLE
Refactor GH Actions job that uses third party action

### DIFF
--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -11,38 +11,39 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: r-lib/actions/setup-r@v1
-      - uses: r-lib/actions/setup-pandoc@v1
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v1
+      - name: Setup pandoc
+        uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
-        run: sudo apt install libcurl4-openssl-dev libssl-dev
-      - name: Run tests
-        run: make test
+        run: sudo apt install libcurl4-openssl-dev libssl-dev python3-pip
+  #     - name: Run tests
+  #       run: make test
       - name: Build and render books
         run: make all
-      - uses: actions/upload-artifact@v1
+      - name: Upload book artifact
+        uses: actions/upload-artifact@v1
         with:
           name: build_book
           path: build/
 
   checkout-and-deploy:
-   runs-on: ubuntu-latest
-   needs: make_books
-   steps:
-     - name: Checkout
-       uses: actions/checkout@master
-     - name: Download artifact
-       uses: actions/download-artifact@v1.0.0
-       with:
-         # Artifact name
-         name: build_book # optional
-         # Destination path
-         path: . # optional
-     - name: Deploy to GitHub Pages
-       uses: Cecilapp/GitHub-Pages-deploy@v3
-       env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-       with:
-          email: ${{ secrets.EMAIL }}
-          build_dir: .                   # optional
-          jekyll: no                     # optional
-
+    runs-on: ubuntu-latest
+    needs: make_books
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+      - name: Download book artifact
+        uses: actions/download-artifact@v1.0.0
+        with:
+          name: build_book
+          path: .
+      - name: Stage changes
+        run: |
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add *
+          git commit -m 'publish built book'
+          git push origin gh-pages

--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -17,8 +17,8 @@ jobs:
         uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
         run: sudo apt install libcurl4-openssl-dev libssl-dev python3-pip
-  #     - name: Run tests
-  #       run: make test
+      - name: Run tests
+        run: make test
       - name: Build and render books
         run: make all
       - name: Upload book artifact
@@ -40,7 +40,7 @@ jobs:
         with:
           name: build_book
           path: .
-      - name: Stage changes
+      - name: Push changes to gh-pages branch
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'


### PR DESCRIPTION
This PR refactors the checkout-and-deploy job so it no longer uses a third party GH Action (which are not allowed on Apache repos unless specifically authorised)