### PR TITLE
remove duplicated sections and add ASF license in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,12 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 github:
   features:
-    # Enable wiki for documentation
-    wiki: false
-    # Enable issue management
     issues: true
-    # Enable projects for project management boards
-    projects: false
-    
-github:
   ghp_branch:  gh-pages
   ghp_path:    .
+


### PR DESCRIPTION
This PR removes the second "github" section header from the config file and adds the Apache license