### PR TITLE
#13 install latest release

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,9 @@
 github:
   features:
     issues: true
+  protected_branches:
+    main:
+      foo: bar # dummy value to make main a dictionary
   ghp_branch:  gh-pages
   ghp_path:    .
 

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -49,7 +49,7 @@ get_installed_version <- function(pkg) {
 #' @param pkg Package name, character.
 load_package <- function(pkg) {
   if (!suppressWarnings(suppressMessages(require(pkg, character.only = TRUE)))) {
-    install.packages(pkg, repos = "https://cran.rstudio.com")
+    install.packages(pkg)
   }
   library(pkg, character.only = TRUE)
 }

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -21,7 +21,7 @@ args <- commandArgs(trailingOnly = TRUE)
 if (length(args) > 0) {
   build_version <- package_version(args[1])
 } else {
-  build_version <- NA
+  build_version <- package_version(available.packages()["arrow", ]["Version"])
 }
 
 #' Get installed version of a package
@@ -56,9 +56,8 @@ load_package <- function(pkg) {
 
 #' Install a specific version of the Arrow R package
 #'
-#' @param build_version The version to install. Default is latest CRAN version.
-install_arrow_version <- function(
-  build_version = package_version(available.packages()["arrow", ]["Version"])) {
+#' @param version_to_install The version to install. Default is latest CRAN version.
+install_arrow_version <- function(version_to_install) {
 
   # TODO: refactor this to get the latest available version on the nightlies 
   # given we set NOT_CRAN = TRUE
@@ -66,14 +65,14 @@ install_arrow_version <- function(
   installed_version <- get_installed_version("arrow")
 
   # Only install the latest released version if it's not already installed
-  if (build_version == latest_release && installed_version != latest_release) {
+  if (version_to_install == latest_release && installed_version != latest_release) {
     Sys.setenv(NOT_CRAN = TRUE)
     install.packages("arrow")
     # Otherwise installed the build version specified if not already installed
     # TODO: refactor this to install the specific version from the nightlies if 
     # a binary is available
-  } else if (installed_version != build_version) {
-    remotes::install_version("arrow", version = build_version)
+  } else if (installed_version != version_to_install) {
+    remotes::install_version("arrow", version = version_to_install)
   }
 }
 

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -48,7 +48,7 @@ get_installed_version <- function(pkg) {
 #'
 #' @param pkg Package name, character.
 load_package <- function(pkg) {
-  if (!require(pkg, character.only = TRUE)) {
+  if (!suppressWarnings(suppressMessages(require(pkg, character.only = TRUE)))) {
     install.packages(pkg, repos = "https://cran.rstudio.com")
   }
   library(pkg, character.only = TRUE)
@@ -59,7 +59,7 @@ load_package <- function(pkg) {
 #' @param version_to_install The version to install. Default is latest CRAN version.
 install_arrow_version <- function(version_to_install) {
 
-  # TODO: refactor this to get the latest available version on the nightlies 
+  # TODO: refactor this to get the latest available version on the nightlies
   # given we set NOT_CRAN = TRUE
   latest_release <- package_version(available.packages()["arrow", ]["Version"])
   installed_version <- get_installed_version("arrow")
@@ -69,7 +69,7 @@ install_arrow_version <- function(version_to_install) {
     Sys.setenv(NOT_CRAN = TRUE)
     install.packages("arrow")
     # Otherwise installed the build version specified if not already installed
-    # TODO: refactor this to install the specific version from the nightlies if 
+    # TODO: refactor this to install the specific version from the nightlies if
     # a binary is available
   } else if (installed_version != version_to_install) {
     remotes::install_version("arrow", version = version_to_install)

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -15,57 +15,54 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# Set the version of Arrow to build based on command line arguments
 args <- commandArgs(trailingOnly = TRUE)
 
-install_release <- FALSE
-build_version <- NA
-
-# get arguments used to run this script
-if (length(args) == 0) {
-  install_release <- TRUE
-} else {
+if (length(args) > 0) {
   build_version <- package_version(args[1])
+} else {
+  build_version <- NA
 }
 
-# get installed version of a package
-get_installed_version <- function(pkg){
+#' Get installed version of a package
+#'
+#' @param pkg Package name, character
+#' @return Package version number, or 0.0.0 if not installed.
+get_installed_version <- function(pkg) {
   tryCatch(
     packageVersion(pkg),
     error = function(e) {
-      return(structure(list(c(0L, 0L, 0L)), class = c("package_version", "numeric_version")))
+      return(
+        structure(
+          list(
+            c(0L, 0L, 0L)
+          ),
+          class = c("package_version", "numeric_version")
+        )
+      )
     }
   )
 }
 
-# install dependencies if not installed
-load_package <- function(pkg_name){
+#' Load package, installing it first if not already installed
+#'
+#' @param pkg Package name, character.
+load_package <- function(pkg) {
   if (!require(pkg_name, character.only = TRUE)) {
-    install.packages(pkg_name)
-  } 
-  library(pkg_name, character.only = TRUE)
+    install.packages(pkg)
+  }
+  library(pkg, character.only = TRUE)
 }
 
-dependencies <- c("testthat", "bookdown", "knitr", "purrr", "remotes", "dplyr")
-
-lapply(dependencies, load_package)
-
-
-
-#' Install the appropriate Arrow version
-#' 
-#' If `build_release` is TRUE, install the latest version of Arrow, else 
-#' installs the specified version 
-#' 
-#' @param release_version Install last released Arrow R package? Logical.
-#' @param build_version The version to install
-install_arrow_version <- function(release_version = FALSE, build_version = NULL){
-  
+#' Install a specific version of the Arrow R package
+#'
+#' @param build_version The version to install. Default value of NA installs the last release.
+install_arrow_version <- function(build_version = NA) {
   installed_version <- get_installed_version("arrow")
-  
-  if (release_version) {
-    
-    last_release <- available.packages()["arrow",]["Version"]
-    
+
+  if (is.na(build_version)) {
+    last_release <- available.packages()["arrow", ]["Version"]
+
     # Only install the latest released version if it's not already installed
     if (package_version(last_release) != installed_version) {
       Sys.setenv(NOT_CRAN = TRUE)
@@ -79,4 +76,7 @@ install_arrow_version <- function(release_version = FALSE, build_version = NULL)
   }
 }
 
-install_arrow_version(install_release, build_version)
+dependencies <- c("testthat", "bookdown", "knitr", "purrr", "remotes", "dplyr")
+lapply(dependencies, load_package)
+
+install_arrow_version(build_version)

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -49,7 +49,7 @@ get_installed_version <- function(pkg) {
 #' @param pkg Package name, character.
 load_package <- function(pkg) {
   if (!require(pkg, character.only = TRUE)) {
-    install.packages(pkg)
+    install.packages(pkg, repos = 'https://cran.rstudio.com')
   }
   library(pkg, character.only = TRUE)
 }

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -77,6 +77,9 @@ install_arrow_version <- function(version_to_install) {
 }
 
 dependencies <- c("testthat", "bookdown", "knitr", "purrr", "remotes", "dplyr")
-lapply(dependencies, load_package)
+
+for (dependency in dependencies) {
+  load_package(dependency)
+}
 
 install_arrow_version(build_version)

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -60,7 +60,7 @@ load_package <- function(pkg) {
 install_arrow_version <- function(version_to_install) {
 
   # TODO: refactor this to get the latest available version on the nightlies
-  # given we set NOT_CRAN = TRUE
+  # given we set NOT_CRAN = TRUE (#29)
   latest_release <- package_version(available.packages()["arrow", ]["Version"])
   installed_version <- get_installed_version("arrow")
 
@@ -70,7 +70,7 @@ install_arrow_version <- function(version_to_install) {
     install.packages("arrow")
     # Otherwise install the build version specified if not already installed
     # TODO: refactor this to install the specific version from the nightlies if
-    # a binary is available
+    # a binary is available (#29)
   } else if (installed_version != version_to_install) {
     remotes::install_version("arrow", version = version_to_install)
   }

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -49,30 +49,31 @@ get_installed_version <- function(pkg) {
 #' @param pkg Package name, character.
 load_package <- function(pkg) {
   if (!require(pkg, character.only = TRUE)) {
-    install.packages(pkg, repos = 'https://cran.rstudio.com')
+    install.packages(pkg, repos = "https://cran.rstudio.com")
   }
   library(pkg, character.only = TRUE)
 }
 
 #' Install a specific version of the Arrow R package
 #'
-#' @param build_version The version to install. Default value of NA installs the last release.
-install_arrow_version <- function(build_version = NA) {
+#' @param build_version The version to install. Default is latest CRAN version.
+install_arrow_version <- function(
+  build_version = package_version(available.packages()["arrow", ]["Version"])) {
+
+  # TODO: refactor this to get the latest available version on the nightlies 
+  # given we set NOT_CRAN = TRUE
+  latest_release <- package_version(available.packages()["arrow", ]["Version"])
   installed_version <- get_installed_version("arrow")
 
-  if (is.na(build_version)) {
-    last_release <- available.packages()["arrow", ]["Version"]
-
-    # Only install the latest released version if it's not already installed
-    if (package_version(last_release) != installed_version) {
-      Sys.setenv(NOT_CRAN = TRUE)
-      install.packages("arrow")
-    }
-  } else {
+  # Only install the latest released version if it's not already installed
+  if (build_version == latest_release && installed_version != latest_release) {
+    Sys.setenv(NOT_CRAN = TRUE)
+    install.packages("arrow")
     # Otherwise installed the build version specified if not already installed
-    if (installed_version != build_version) {
-      remotes::install_version("arrow", version = build_version)
-    }
+    # TODO: refactor this to install the specific version from the nightlies if 
+    # a binary is available
+  } else if (installed_version != build_version) {
+    remotes::install_version("arrow", version = build_version)
   }
 }
 

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -1,8 +1,11 @@
 args <- commandArgs(trailingOnly = TRUE)
 
+install_release <- FALSE
+build_version <- NA
+
 # get arguments used to run this script
 if (length(args) == 0) {
-  build_version = "latest"
+  install_release <- TRUE
 } else {
   build_version <- package_version(args[1])
 }
@@ -18,17 +21,50 @@ get_installed_version <- function(pkg){
 }
 
 # install dependencies if not installed
-if (!require("pacman")) install.packages("pacman")
-pacman::p_load("testthat", "bookdown", "xfun", "knitr", "purrr", "remotes", "dplyr")
-pacman::p_load_gh("rmflight/testrmd")
-
-# check version of Arrow installed, and install correct one
-if (!inherits(build_version, "package_version") && build_version == "latest") {
-  install.packages("arrow", repos = c("https://arrow-r-nightly.s3.amazonaws.com", getOption("repos")))
-} else {
-  installed_version <- get_installed_version("arrow")
-  if (installed_version != build_version) {
-    pkg_url <- paste0("https://cran.r-project.org/src/contrib/Archive/arrow/arrow_", build_version, ".tar.gz")
-    install.packages(pkg_url, repos = NULL, type = "source")
-  }
+load_package <- function(pkg_name){
+  if (!require(pkg_name, character.only = TRUE)) {
+    install.packages(pkg_name)
+  } 
+  library(pkg_name, character.only = TRUE)
 }
+
+dependencies <- c("testthat", "bookdown", "knitr", "purrr", "remotes", "dplyr")
+
+lapply(dependencies, load_package)
+
+
+
+#' Install the appropriate Arrow version
+#' 
+#' If `build_release` is TRUE, install the latest version of Arrow, else 
+#' installs the specified version 
+#' 
+#' @param release_version Install last released Arrow R package? Logical.
+#' @param build_version The version to install
+install_arrow_version <- function(release_version = FALSE, build_version = NULL){
+  
+  installed_version <- get_installed_version("arrow")
+  
+  if (release_version) {
+    
+    last_release <- available.packages()["arrow",]["Version"]
+    
+    # Only install the latest released version if it's not already installed
+    if (package_version(last_release) != installed_version) {
+      Sys.setenv(NOT_CRAN = TRUE)
+      install.packages("arrow")
+    }
+    
+  } else {
+    
+    # Otherwise installed the build version specified if not already installed
+    if (installed_version != build_version) {
+      pkg_url <- paste0("https://cran.r-project.org/src/contrib/Archive/arrow/arrow_", build_version, ".tar.gz")
+      install.packages(pkg_url, repos = NULL, type = "source")
+    }
+    
+  }
+
+}
+
+install_arrow_version(install_release)

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 args <- commandArgs(trailingOnly = TRUE)
 
 install_release <- FALSE
@@ -54,17 +71,12 @@ install_arrow_version <- function(release_version = FALSE, build_version = NULL)
       Sys.setenv(NOT_CRAN = TRUE)
       install.packages("arrow")
     }
-    
   } else {
-    
     # Otherwise installed the build version specified if not already installed
     if (installed_version != build_version) {
-      pkg_url <- paste0("https://cran.r-project.org/src/contrib/Archive/arrow/arrow_", build_version, ".tar.gz")
-      install.packages(pkg_url, repos = NULL, type = "source")
+      remotes::install_version("arrow", version = build_version)
     }
-    
   }
-
 }
 
-install_arrow_version(install_release)
+install_arrow_version(install_release, build_version)

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -48,7 +48,7 @@ get_installed_version <- function(pkg) {
 #'
 #' @param pkg Package name, character.
 load_package <- function(pkg) {
-  if (!require(pkg_name, character.only = TRUE)) {
+  if (!require(pkg, character.only = TRUE)) {
     install.packages(pkg)
   }
   library(pkg, character.only = TRUE)

--- a/r/scripts/install_dependencies.R
+++ b/r/scripts/install_dependencies.R
@@ -68,7 +68,7 @@ install_arrow_version <- function(version_to_install) {
   if (version_to_install == latest_release && installed_version != latest_release) {
     Sys.setenv(NOT_CRAN = TRUE)
     install.packages("arrow")
-    # Otherwise installed the build version specified if not already installed
+    # Otherwise install the build version specified if not already installed
     # TODO: refactor this to install the specific version from the nightlies if
     # a binary is available
   } else if (installed_version != version_to_install) {


### PR DESCRIPTION
Fixes #13   - When installing the R dependencies, the default behaviour is now to install the latest released version of the Arrow R package.