### PR TITLE
Change gh-pages deploy to a single commit

### DIFF
--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
+          git checkout --orphan gh-pages-tmp
           git add *
           git commit -m 'publish built book'
-          git push origin gh-pages
+          git push -f origin gh-pages-tmp:gh-pages


### PR DESCRIPTION
Right now the deploy operation checks out the current gh-pages branch, does a `git add *` to update it, and then pushes it.  However, this has some downsides, most of which could be worked around with more complexity:

* If files are removed they won't disappear from gh-pages.
* If binary files (e.g. images, test data) change often they can clutter up the git repo (this is kind of an argument against any impl of gh-pages though)
* If no files changed it can fail the build because the commit / push will fail

An alternative method is to just force push a brand new branch with a single commit every single time which is what this PR does.