### PR TITLE
Publish to gh-pages

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -26,4 +26,5 @@ github:
   collaborators:
     - thisisnic
     - amol-
-
+  publish:
+    whoami:   gh-pages


### PR DESCRIPTION
Currently gh-pages isn't working on this repo.  Taking a look at the Apache Airflow config file, we may have to add the publish field.

See: https://github.com/apache/airflow-site/blob/main/.asf.yaml