### PR TITLE
Temporarily removing collaborators ending in -

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -25,7 +25,6 @@ github:
   ghp_path:    .
   collaborators:
     - thisisnic
-    - amol-
 
 notifications:
   commits:      commits@arrow.apache.org


### PR DESCRIPTION
ASF Infra has a regex to test if a username is a valid GH username.  GH does not allow usernames to end in hyphen.  However, they did allow this at one point and they grandfathered in some names.  ASF Infra is rejecting these grandfathered in names.