### PR TITLE
Copy .asf.yaml to asf-site branch

### DIFF
--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git add *
+          git add --all
           git commit -m 'publish built book'
           git push -f origin gh-pages-tmp:gh-pages
           git push -f origin gh-pages-tmp:asf-site

--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -38,6 +38,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           ref: gh-pages
+      - name: Prepare branch
+        run: |
+          git checkout --orphan gh-pages-tmp
+          git rm -rf .
       - name: Download book artifact
         uses: actions/download-artifact@v1.0.0
         with:
@@ -47,7 +51,6 @@ jobs:
         run: |
           git config --global user.name 'GitHub Actions'
           git config --global user.email 'actions@github.com'
-          git checkout --orphan gh-pages-tmp
           git add *
           git commit -m 'publish built book'
           git push -f origin gh-pages-tmp:gh-pages

--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -21,6 +21,8 @@ jobs:
         run: make test
       - name: Build and render books
         run: make all
+      - name: Copy .asf.yaml
+        run: cp .asf.yaml build/.asf.yaml
       - name: Upload book artifact
         uses: actions/upload-artifact@v1
         with:


### PR DESCRIPTION
I think the reason the deploy didn't work was because the .asf.yaml file has to be on the asf-site branch.  This PR changes that.  It also tweaks the orphan-deploy process a little bit because the old one was leaving behind cached files.  Now it removes all files, downloads the book, then uploads everything.