### PR TITLE
[CI] Run apt update before apt install

### DIFF
--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Setup pandoc
         uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
-        run: sudo apt install libcurl4-openssl-dev libssl-dev python3-pip openjdk-11-jdk maven
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev libssl-dev python3-pip openjdk-11-jdk maven
       - name: Run tests
         run: make test
       - name: Build and render books

--- a/.github/workflows/test_java_linux_cookbook.yml
+++ b/.github/workflows/test_java_linux_cookbook.yml
@@ -24,7 +24,7 @@ on:
     paths:
      - "java/**"
      - ".github/workflows/test_java_linux_cookbook.yml"
-     
+
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -40,9 +40,10 @@ jobs:
           distribution: 'temurin'
           java-version: '11'
       - name: Install dependencies
-        run: sudo apt install libcurl4-openssl-dev libssl-dev python3-pip maven
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev libssl-dev python3-pip maven
       - name: Run tests
         run: make javatest
       - name: Build cookbook
         run: make java
-

--- a/.github/workflows/test_python_cookbook.yml
+++ b/.github/workflows/test_python_cookbook.yml
@@ -24,7 +24,7 @@ on:
     paths:
      - "python/**"
      - ".github/workflows/test_python_cookbook.yml"
-     
+
 concurrency:
   group: ${{ github.repository }}-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
@@ -36,9 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install dependencies
-        run: sudo apt install libcurl4-openssl-dev libssl-dev python3-pip
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev libssl-dev python3-pip
       - name: Run tests
         run: make pytest
       - name: Build cookbook
         run: make py
-

--- a/.github/workflows/test_r_cookbook.yml
+++ b/.github/workflows/test_r_cookbook.yml
@@ -40,9 +40,10 @@ jobs:
       - name: Setup pandoc
         uses: r-lib/actions/setup-pandoc@v1
       - name: Install dependencies
-        run: sudo apt install libcurl4-openssl-dev libssl-dev
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev libssl-dev
       - name: Run tests
         run: make rtest
       - name: Build cookbooks
         run: make r
-


### PR DESCRIPTION
This is [recommended](https://docs.github.com/en/actions/using-github-hosted-runners/customizing-github-hosted-runners#installing-software-on-ubuntu-runners) by the GitHub documentation because the apt package lists may be out-of-date in the runners, leading to spurious errors.