### PR TITLE
Include Python Server Client Example with Certificates

### DIFF
--- a/python/source/create.rst
+++ b/python/source/create.rst
@@ -107,7 +107,7 @@ from numpy and pandas arrays and series, but it's also
 possible to create Arrow Arrays and Tables from 
 plain Python structures.
 
-the :func:`pyarrow.table` function allows creation of Tables
+The :func:`pyarrow.table` function allows creation of Tables
 from a variety of inputs, including plain python objects
 
 .. testcode::

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -634,6 +634,7 @@ The code below is a minimal working example of an Arrow server used to receive d
     import pyarrow
     import pyarrow.flight
     
+    
     class FlightServer(pyarrow.flight.FlightServerBase):
         def __init__(self, host="localhost", location=None,
                      tls_certificates=None, verify_client=False,
@@ -655,6 +656,7 @@ The code below is a minimal working example of an Arrow server used to receive d
             print(key)
             self.flights[key] = reader.read_all()
             print(self.flights[key])
+    
     
     def main():
         parser = argparse.ArgumentParser()

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -631,6 +631,7 @@ The code below is a minimal working example of an Arrow server used to receive d
 
 .. testcode::
     import argparse
+    import pyarrow
     import pyarrow.flight
     
     class FlightServer(pyarrow.flight.FlightServerBase):

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -644,8 +644,6 @@ The code below is a minimal working example of an Arrow server used to receive d
                 location, auth_handler, tls_certificates, verify_client,
                 root_certificates)
             self.flights = {}
-            self.host = host
-            self.tls_certificates = tls_certificates
     
         @classmethod
         def descriptor_to_key(self, descriptor):

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -630,6 +630,7 @@ One method to achieve this is openssl, please visit this `IBM article`_ for more
 The code below is a minimal working example of an Arrow server used to receive data with TLS. For a full server example, please visit the Arrow `GitHub repo`_. 
 
 .. testcode::
+    
     import argparse
     import pyarrow
     import pyarrow.flight
@@ -693,6 +694,7 @@ Suppose we want to connect to the client and push some data to it. The following
 The example below shows how one could  
 
 .. testcode::
+    
     import argparse
     import pyarrow
     import pyarrow.flight

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -721,7 +721,7 @@ Suppose we want to connect to the client and push some data to it. The following
         with open(args.tls_roots, "rb") as root_certs:
             kwargs["tls_root_certs"] = root_certs.read()
     
-        client = pyarrow.flight.FlightClient(f"grpc+tls://{args.host}:{args.port}", ****kwargs)
+        client = pyarrow.flight.FlightClient(f"grpc+tls://{args.host}:{args.port}", **kwargs)
         data = {'Animal': ['Dog', 'Cat', 'Mouse'], 'Size': ['Big', 'Small', 'Tiny']}
         df = pd.DataFrame(data, columns=['Animal', 'Size'])
         push_to_server("AnimalData", df, client)

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -606,14 +606,14 @@ Or if we use the wrong credentials on login, we also get an error:
 
 .. _(HTTP) basic authentication: https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme
 
-Authentication with certificates
+Securing connections with TLS
 =================================
 
 Following on from the previous scenario where traffic to the server is managed via a username and password, 
 HTTPS (more specifically TLS) communication allows an additional layer of security by encrypting messages
 between the client and server. This is achieved using certificates. During development, the easiest 
 approach is developing with self-signed certificates. At startup, the server loads the public and private 
-key and the client client authenticates itself to the server with the tls root certificate.
+key and the client authenticates the server with the TLS root certificate.
 
 .. note:: In production environments it is recommended to make use of a certificate signed by a certificate authority.
 
@@ -627,7 +627,7 @@ One method to achieve this is openssl, please visit this `IBM article`_ for more
 
 **Step 2 - Running a server with TLS enabled**
 
-The code below is a minimal working example of an Arrow server used to receive data with TLS. For a full server example, please visit the Arrow `GitHub repo`_. 
+The code below is a minimal working example of an Arrow server used to receive data with TLS.
 
 .. testcode::
     
@@ -691,7 +691,6 @@ Running the server, you should see ``Serving on grpc+tls://localhost:5005``.
 
 **Step 3 - Securely Connecting to the Server**
 Suppose we want to connect to the client and push some data to it. The following code securely sends information to the server using TLS encryption.
-The example below shows how one could  
 
 .. testcode::
     
@@ -700,11 +699,11 @@ The example below shows how one could
     import pyarrow.flight
     import pandas as pd
     
-    # Assumes incoming data object is a Dataframe
+    # Assumes incoming data object is a Pandas Dataframe
     def push_to_server(name, data, client):
-        objectToSend = pyarrow.Table.from_pandas(data)
-        writer, _ = client.do_put(pyarrow.flight.FlightDescriptor.for_path(name), objectToSend.schema)
-        writer.write_table(objectToSend)
+        object_to_send = pyarrow.Table.from_pandas(data)
+        writer, _ = client.do_put(pyarrow.flight.FlightDescriptor.for_path(name), object_to_send.schema)
+        writer.write_table(object_to_send)
         writer.close()
     
     def main():
@@ -717,12 +716,12 @@ The example below shows how one could
         parser.add_argument('--port', default=5005,
                             help='Host port')
         args = parser.parse_args()
-        connection_args = {}
+        kwargs = {}
     
         with open(args.tls_roots, "rb") as root_certs:
-            connection_args["tls_root_certs"] = root_certs.read()
+            kwargs["tls_root_certs"] = root_certs.read()
     
-        client = pyarrow.flight.FlightClient(f"grpc+tls://{args.host}:{args.port}", **connection_args)
+        client = pyarrow.flight.FlightClient(f"grpc+tls://{args.host}:{args.port}", ****kwargs)
         data = {'Animal': ['Dog', 'Cat', 'Mouse'], 'Size': ['Big', 'Small', 'Tiny']}
         df = pd.DataFrame(data, columns=['Animal', 'Size'])
         push_to_server("AnimalData", df, client)
@@ -736,7 +735,6 @@ The example below shows how one could
 Running the client script, you should see the server printing out information about the data it just received.
 
 .. _IBM article: https://www.ibm.com/docs/en/arl/9.7?topic=certification-extracting-certificate-keys-from-pfx-file
-.. _GitHub repo: https://github.com/apache/arrow/blob/master/python/examples/flight/server.py
 .. _Windows: https://docs.microsoft.com/en-us/dotnet/core/additional-tools/self-signed-certificates-guide
 .. _Arrow testing data repository: https://github.com/apache/arrow-testing/tree/master/data/flight
 .. _openssl: https://www.ibm.com/docs/en/api-connect/2018.x?topic=overview-generating-self-signed-certificate-using-openssl

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -697,32 +697,32 @@ The example below shows how one could
     import pandas as pd
     
     # Assumes incoming data object is a Dataframe
-    def pushToServer(name, data, client):
+    def push_to_server(name, data, client):
         objectToSend = pyarrow.Table.from_pandas(data)
         writer, _ = client.do_put(pyarrow.flight.FlightDescriptor.for_path(name), objectToSend.schema)
         writer.write_table(objectToSend)
         writer.close()
     
-    def _add_common_arguments(parser):
-        parser.add_argument('--tls', action='store_true',
-                            help='Enable transport-level security')
-        parser.add_argument('--tls-roots', default=None,
-                            help='Path to trusted TLS certificate(s)')
-                    
     def main():
         parser = argparse.ArgumentParser()
+    
+        parser.add_argument('--tls-roots', default=None,
+                            help='Path to trusted TLS certificate(s)')
+        parser.add_argument('--host', default="localhost",
+                            help='Host endpoint')
+        parser.add_argument('--port', default=5005,
+                            help='Host port')
         args = parser.parse_args()
         connection_args = {}
-        scheme = "grpc+tls"
-        
+    
         with open(args.tls_roots, "rb") as root_certs:
             connection_args["tls_root_certs"] = root_certs.read()
-        
-        client = pyarrow.flight.FlightClient(f"{scheme}://{host}:{port}", **connection_args)
-        data =  { 'Animal': ['Dog', 'Cat', 'Mouse'], 'Size': ['Big', 'Small', 'Tiny'] }    
+    
+        client = pyarrow.flight.FlightClient(f"grpc+tls://{args.host}:{args.port}", **connection_args)
+        data = {'Animal': ['Dog', 'Cat', 'Mouse'], 'Size': ['Big', 'Small', 'Tiny']}
         df = pd.DataFrame(data, columns=['Animal', 'Size'])
         push_to_server("AnimalData", df, client)
-        
+    
     if __name__ == '__main__':
         try:
             main()

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -690,6 +690,7 @@ Suppose we want to connect to the client and push some data to it. The following
 The example below shows how one could  
 
 .. testcode::
+    import argparse
     import pyarrow
     import pyarrow.flight
     import pandas as pd

--- a/python/source/flight.rst
+++ b/python/source/flight.rst
@@ -641,11 +641,7 @@ called with the path to the public and private keys.
 .. testcode::
     python server.py --tls CERTFILE <PathToPublicCertificate> --tls KEYFILE <PathToPrivateKey>
 
-Assuming the path was valid, you should see the server being served on a port set in the code (or by you).
-
-.. testoutput::
-    
-    Serving on grpc+tls://localhost:5005
+Assuming the path was valid, you should see ``Serving on grpc+tls://localhost:5005``. The server is now being served on a port set in the code (or by you).
 
 **Step 4 - Securely Connecting a client to the Server**
 Suppose we want to connect to the client and push some data to it. The following code securely sends information to the server using TLS encryption. 


### PR DESCRIPTION
- Minor capitalisation fix in create.rst
- User example of how to set up an arrow server using self-signed certificates