### PR TITLE
Add link to Rust examples

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -42,6 +42,7 @@
 			<li><a href="java/index.html">Java Cookbook</a></li>
 			<li><a href="py/index.html">Python Cookbook</a></li>
 			<li><a href="r/index.html">R Cookbook</a></li>
+			<li><a href="https://github.com/apache/arrow-rs/tree/master/arrow/examples">Rust Examples</a></li>
 		</ul>
 		<p>If you are looking for the Apache Arrow Documentation itself
 		   or the API reference, those are available at


### PR DESCRIPTION
# Rationale

It would be nice if the Rust examples were easier to find / discover.

Closes https://github.com/apache/arrow-cookbook/issues/182

# Changes
As suggested by @westonpace  and @yuribudilov on  https://github.com/apache/arrow-cookbook/issues/182#issuecomment-1097357772 add a link to the Rust examples

Upon review, the rust examples could be improved as well -- I will file a follow on ticket for that work