### PR TITLE
[Java][Python] Bump to Arrow 9.0.0

### DIFF
--- a/java/source/demo/pom.xml
+++ b/java/source/demo/pom.xml
@@ -31,7 +31,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <arrow.version>8.0.0</arrow.version>
+        <arrow.version>9.0.0</arrow.version>
     </properties>
 
     <dependencies>

--- a/java/source/index.rst
+++ b/java/source/index.rst
@@ -28,6 +28,8 @@ The Apache Arrow Cookbook is a collection of recipes which demonstrate how to so
 To get started with Apache Arrow in Java, see the
 `Installation Instructions <https://arrow.apache.org/docs/java/install.html>`_.
 
+This cookbook is tested with **Apache Arrow 9.0.0**.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,3 @@
 Sphinx>=4.0.2
-pyarrow>=8.0.0
+pyarrow==9.0.0
 pandas>=1.2.5

--- a/python/source/index.rst
+++ b/python/source/index.rst
@@ -11,6 +11,8 @@ how to solve many common tasks that users might need to perform
 when working with arrow data.  The examples in this cookbook will also
 serve as robust and well performing solutions to those tasks.
 
+This cookbook is tested with **pyarrow 9.0.0**.
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:


### PR DESCRIPTION
C++ and R are not bumped (the Conda/CRAN packages are not yet updated)