### PR TITLE
[C++] Add C++ build against Arrow Nightlies version

### DIFF
--- a/.github/workflows/test_cpp_cookbook.yml
+++ b/.github/workflows/test_cpp_cookbook.yml
@@ -30,8 +30,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test_cpp:
-    name: "Test C++ Cookbook"
+  test_cpp_stable:
+    name: "Test C++ Cookbook on Arrow stable"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -66,3 +66,29 @@ jobs:
           name: cpp_book
           path: build/cpp
 
+  test_cpp_dev:
+    name: "Test C++ Cookbook on Arrow Nightlies"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: cookbook-cpp-dev
+          environment-file: cpp/dev.yml
+          auto-activate-base: false
+      - name: Test
+        run:
+          echo ${CONDA_PREFIX}
+      - name: Build cookbook
+        run:
+          make cpp
+      - name: Upload cpp book
+        uses: actions/upload-artifact@v1
+        with:
+          name: cpp_book
+          path: build/cpp

--- a/cpp/CONTRIBUTING.md
+++ b/cpp/CONTRIBUTING.md
@@ -136,7 +136,8 @@ output by running `make html` in the `cpp` directory.
 ## Using Conda
 
 If you are using conda then there is file `cpp/requirements.yml` which can be
-used to create an environment for recipe development with the command:
+used to create an environment for recipe development using the latest stable
+Arrow version with the command:
 
 ```
 conda env create -f cpp/environment.yml
@@ -155,6 +156,15 @@ To update dependencies modify `cpp/requirements.yml` and then run
 cd cpp
 conda-lock --file environment.yml --kind explicit -p linux-aarch64 -p linux-64 -p osx-arm64
 ```
+
+You can also create a conda environment to test your cookbooks against the Arrow Nightly
+builds using the file `cpp/dev.yml`. Using the command:
+
+```
+conda env create -f cpp/dev.yml
+```
+
+This will create a conda environment called cookbook-cpp-dev instead.
 
 # Development Philosophy
 

--- a/cpp/code/CMakeLists.txt
+++ b/cpp/code/CMakeLists.txt
@@ -25,12 +25,13 @@ endif()
 
 # Add Arrow and other required packages
 find_package(Arrow REQUIRED)
-
-if(${ARROW_VERSION} VERSION_GREATER "9.0.0")
-    find_package(ArrowDataset REQUIRED)
-    find_package(ArrowFlight REQUIRED)
-    find_package(Parquet REQUIRED)
+if(NOT ${ARROW_VERSION} VERSION_GREATER "9.0.0")
+  get_filename_component(ARROW_CMAKE_BASE_DIR ${Arrow_CONFIG} DIRECTORY)
+  list(INSERT CMAKE_MODULE_PATH 0 ${ARROW_CMAKE_BASE_DIR})
 endif()
+find_package(ArrowDataset REQUIRED)
+find_package(ArrowFlight REQUIRED)
+find_package(Parquet REQUIRED)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_CLANG_TIDY "clang-tidy")

--- a/cpp/code/CMakeLists.txt
+++ b/cpp/code/CMakeLists.txt
@@ -48,7 +48,7 @@ function(RECIPE TARGET)
             common.cc
             main.cc
     )
-    if(${ARROW_VERSION} VERSION_GREATER "9.0.0")
+    if(TARGET Arrow::arrow_shared)
         set(ARROW_SHARED_NAME Arrow::arrow_shared)
     else()
         set(ARROW_SHARED_NAME arrow_shared)

--- a/cpp/code/CMakeLists.txt
+++ b/cpp/code/CMakeLists.txt
@@ -23,8 +23,14 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libstdc++")
 endif()
 
-# Add Arrow
-find_package(Arrow REQUIRED COMPONENTS dataset flight parquet)
+# Add Arrow and other required packages
+find_package(Arrow REQUIRED)
+
+if(${ARROW_VERSION} VERSION_GREATER "9.0.0")
+    find_package(ArrowDataset REQUIRED)
+    find_package(ArrowFlight REQUIRED)
+    find_package(Parquet REQUIRED)
+endif()
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     set(CMAKE_CXX_CLANG_TIDY "clang-tidy")
@@ -42,9 +48,14 @@ function(RECIPE TARGET)
             common.cc
             main.cc
     )
+    if(${ARROW_VERSION} VERSION_GREATER "9.0.0")
+        set(ARROW_SHARED_NAME Arrow::arrow_shared)
+    else()
+        set(ARROW_SHARED_NAME arrow_shared)
+    endif()
     target_link_libraries(
             ${TARGET}
-            arrow_shared
+            ${ARROW_SHARED_NAME}
             arrow_dataset
             arrow_flight
             parquet

--- a/cpp/code/CMakeLists.txt
+++ b/cpp/code/CMakeLists.txt
@@ -50,18 +50,17 @@ function(RECIPE TARGET)
             main.cc
     )
     if(TARGET Arrow::arrow_shared)
-        set(ARROW_SHARED_NAME Arrow::arrow_shared)
-    else()
-        set(ARROW_SHARED_NAME arrow_shared)
-    endif()
-    target_link_libraries(
+        target_link_libraries(
             ${TARGET}
-            ${ARROW_SHARED_NAME}
-            arrow_dataset
-            arrow_flight
-            parquet
-            gtest
-    )
+            ArrowDataset::arrow_dataset_shared
+            ArrowFlight::arrow_flight_shared gtest
+        )
+    else()
+        target_link_libraries(parquet_shared INTERFACE arrow_shared)
+        target_link_libraries(arrow_dataset_shared INTERFACE parquet_shared)
+        target_link_libraries(arrow_flight_shared INTERFACE arrow_shared)
+        target_link_libraries(${TARGET} arrow_dataset_shared arrow_flight_shared gtest)
+    endif()
     if (MSVC)
         target_compile_options(${TARGET} PRIVATE /W4 /WX)
     else ()

--- a/cpp/dev.yml
+++ b/cpp/dev.yml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: cookbook-cpp-dev
+channels:
+  - arrow-nightlies
+  - conda-forge
+dependencies:
+  - python=3.8
+  - compilers
+  - arrow-nightlies::arrow-cpp
+  - sphinx
+  - gtest
+  - gmock
+  - arrow-nightlies::pyarrow
+  - clang-tools


### PR DESCRIPTION
This PR is the first one to be able to build the different cookbooks against the latest development version of Arrow using the Nightly built packages.
Once we can build the different cookbooks with both a stable release and the Nightly version we will be able to deploy a development version of the cookbooks.
This PR also fixes our CMake build to be compatible with the new and old versions