### PR TITLE
[Java] Update create.rst to address typos: "slice" was written as "splice" #259

### DIFF
--- a/java/source/create.rst
+++ b/java/source/create.rst
@@ -187,12 +187,12 @@ Array of List
 
 
 Slicing
-========
+=======
 
 Slicing provides a way of copying a range of rows between two vectors of the same type.
 
 Slicing IntVector
-------------------
+-----------------
 
 In this example, we copy a portion of the input IntVector to a new IntVector.
 

--- a/java/source/create.rst
+++ b/java/source/create.rst
@@ -186,12 +186,12 @@ Array of List
    [[1,2,3], [10,20,30], [100,200,300], [1000,2000,3000]]
 
 
-Splicing
+Slicing
 ========
 
-Splicing provides a way of copying a range of rows between two vectors of the same type.
+Slicing provides a way of copying a range of rows between two vectors of the same type.
 
-Splicing IntVector
+Slicing IntVector
 ------------------
 
 In this example, we copy a portion of the input IntVector to a new IntVector.


### PR DESCRIPTION
The word "splice" was inadvertently written instead of "slice" in a few places. Changed the text