### PR TITLE
[C++] Improve C++ Cookbook

### DIFF
--- a/cpp/code/basic_arrow.cc
+++ b/cpp/code/basic_arrow.cc
@@ -35,6 +35,11 @@ arrow::Status ReturnNotOkMacro() {
     if (!st.ok()) {
       return st;
     }
+    auto res = builder.Finish();
+    std::shared_ptr<arrow::Array> arr;
+    if (res.ok()) {
+      arr = std::move(res).ValueUnsafe();
+    }
     rout << "Appended -1 null values?" << std::endl;
     return arrow::Status::OK();
   };
@@ -47,14 +52,15 @@ arrow::Status ReturnNotOkMacro() {
 
 arrow::Status ReturnNotOk() {
   StartRecipe("ReturnNotOk");
-  std::function<arrow::Status()> test_fn = [] {
+  auto test_fn = [] {
     arrow::NullBuilder builder;
     ARROW_RETURN_NOT_OK(builder.Reserve(2));
     ARROW_RETURN_NOT_OK(builder.AppendNulls(-1));
+    ARROW_ASSIGN_OR_RAISE(auto arr, builder.Finish());
     rout << "Appended -1 null values?" << std::endl;
     return arrow::Status::OK();
   };
-  arrow::Status st = test_fn();
+  auto st = test_fn();
   rout << st << std::endl;
   EndRecipe("ReturnNotOk");
   EXPECT_FALSE(st.ok());
@@ -70,48 +76,48 @@ TEST(BasicArrow, ReturnNotOk) { ASSERT_OK(ReturnNotOk()); }
 /// Only supports floating point and integral types. Does not support decimals.
 class TableSummation {
   double partial = 0.0;
- public:
 
+ public:
   arrow::Result<double> Compute(std::shared_ptr<arrow::RecordBatch> batch) {
-    for (std::shared_ptr<arrow::Array> array : batch->columns()) {
+    for (const auto& array : batch->columns()) {
       ARROW_RETURN_NOT_OK(arrow::VisitArrayInline(*array, this));
     }
     return partial;
   }
 
   // Default implementation
-  arrow::Status Visit(const arrow::Array& array) {
-    return arrow::Status::NotImplemented("Can not compute sum for array of type ",
-                                         array.type()->ToString());
-  }
-
   template <typename ArrayType, typename T = typename ArrayType::TypeClass>
-  arrow::enable_if_number<T, arrow::Status> Visit(const ArrayType& array) {
-    for (arrow::util::optional<typename T::c_type> value : array) {
-      if (value.has_value()) {
-        partial += static_cast<double>(value.value());
+  arrow::Status Visit(const ArrayType& array) {
+    if constexpr (arrow::is_number_type<T>::value) {
+      for (auto value : array) {
+        if (value.has_value()) {
+          partial += static_cast<double>(value.value());
+        }
       }
+      return arrow::Status::OK();
+    } else {
+      return arrow::Status::NotImplemented("Can not compute sum for array of type ",
+                                           array.type()->ToString());
     }
-    return arrow::Status::OK();
   }
 };  // TableSummation
 
 arrow::Status VisitorSummationExample() {
   StartRecipe("VisitorSummationExample");
-  std::shared_ptr<arrow::Schema> schema = arrow::schema({
+  auto schema = arrow::schema({
       arrow::field("a", arrow::int32()),
       arrow::field("b", arrow::float64()),
   });
   int32_t num_rows = 3;
   std::vector<std::shared_ptr<arrow::Array>> columns;
 
-  arrow::Int32Builder a_builder = arrow::Int32Builder();
+  arrow::Int32Builder a_builder;
   std::vector<int32_t> a_vals = {1, 2, 3};
   ARROW_RETURN_NOT_OK(a_builder.AppendValues(a_vals));
   ARROW_ASSIGN_OR_RAISE(auto a_arr, a_builder.Finish());
   columns.push_back(a_arr);
 
-  arrow::DoubleBuilder b_builder = arrow::DoubleBuilder();
+  arrow::DoubleBuilder b_builder;
   std::vector<double> b_vals = {4.0, 5.0, 6.0};
   ARROW_RETURN_NOT_OK(b_builder.AppendValues(b_vals));
   ARROW_ASSIGN_OR_RAISE(auto b_arr, b_builder.Finish());

--- a/cpp/source/basic.rst
+++ b/cpp/source/basic.rst
@@ -41,9 +41,9 @@ tedious:
   :caption: Checking the status of every function manually
   :dedent: 2
 
-The macro :c:macro:`ARROW_RETURN_NOT_OK` will take care of some of this
-boilerplate for you.  It will run the contained expression and check the resulting
-``Status`` or ``Result`` object.  If it failed then it will return the failure.
+The macros :c:macro:`ARROW_RETURN_NOT_OK` and :c:macro:`ARROW_ASSIGN_OR_RAISE` will take care of some of these
+boilerplates for you.  They will run the contained expression and check the resulting
+``Status`` or ``Result`` object.  If they failed then they will return the failure.
 
 .. recipe:: ../code/basic_arrow.cc ReturnNotOk
   :caption: Using ARROW_RETURN_NOT_OK to check the status
@@ -63,6 +63,14 @@ efficiently:
  * :cpp:func:`arrow::VisitScalarInline`
  * :cpp:func:`arrow::VisitArrayInline`
 
+Alternatively, you can implement a visitor class that inherits the base visitor classes provided.
+
+ * :cpp:class:`arrow::TypeVisitor`
+ * :cpp:class:`arrow::ScalarVisitor`
+ * :cpp:class:`arrow::ArrayVisitor`
+
+Visitor classes can be used with the Accept function of their corresponding classes.
+
 Generate Random Data
 --------------------
 
@@ -78,7 +86,7 @@ excessively verbose. Fortunately, Arrow provides type traits that allow you to
 write templated functions to handle subsets of types. The example below
 demonstrates a table sum function that can handle any integer or floating point 
 array with only a single visitor implementation by leveraging
-:cpp:type:`arrow::enable_if_number`.
+:cpp:type:`arrow::is_number_type`.
 
 .. literalinclude:: ../code/basic_arrow.cc
    :language: cpp


### PR DESCRIPTION
ARROW-17851
Add ARROW_ASSIGN_OR_RAISE to utility macros.
Use auto when it improves readability.
Adopt C++ 14/17's idioms.
Add Visitor classes to visitor pattern.