### PR TITLE
[CI] Run cookbook recipes against arrow nightlies only manually and scheduled

### DIFF
--- a/.github/workflows/test_arrow_nightly_cookbook.yml
+++ b/.github/workflows/test_arrow_nightly_cookbook.yml
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: Test Cookbook against Arrow Nightly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
+
+jobs:
+  test_r_dev:
+    name: "Test R Cookbook on Arrow Nightlies"
+    runs-on: ubuntu-latest
+    env:
+      ARROW_NIGHTLY: 1
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+      - name: Setup pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev libssl-dev
+      - name: Run tests
+        run: make rtest
+      - name: Build cookbooks
+        run: make r
+
+  test_cpp_dev:
+    name: "Test C++ Cookbook on Arrow Nightlies"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup environment
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          activate-environment: cookbook-cpp-dev
+          environment-file: cpp/dev.yml
+          auto-activate-base: false
+      - name: Test
+        run:
+          echo ${CONDA_PREFIX}
+      - name: Build cookbook
+        run:
+          make cpp
+      - name: Upload cpp book
+        uses: actions/upload-artifact@v1
+        with:
+          name: cpp_book
+          path: build/cpp
+
+  test_py_dev:
+    name: "Test Python Cookbook on Arrow Nightlies"
+    runs-on: ubuntu-latest
+    env:
+      ARROW_NIGHTLY: 1
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev libssl-dev python3-pip
+      - name: Run tests
+        run: make pytest
+      - name: Build cookbook
+        run: make py
+
+  test_java_osx_dev:
+    name: "Test Java Cookbook MacOS on Arrow Nightlies"
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9' ]
+        java-version: [ '18' ]
+        arrow_nightly: ['1']
+    env:
+      ARROW_NIGHTLY: ${{ matrix.arrow_nightly }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+      - name: Run tests
+        run: make javatest
+      - name: Build cookbook
+        run: make java
+
+  test_java_linux_dev:
+    name: "Test Java Cookbook Linux on Arrow Nightlies"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.9' ]
+        java-version: [ '18' ]
+        arrow_nightly: ['1']
+    env:
+      ARROW_NIGHTLY: ${{ matrix.arrow_nightly }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install libcurl4-openssl-dev libssl-dev
+      - name: Run tests
+        run: make javatest
+      - name: Build cookbook
+        run: make java

--- a/.github/workflows/test_cpp_cookbook.yml
+++ b/.github/workflows/test_cpp_cookbook.yml
@@ -65,30 +65,3 @@ jobs:
         with:
           name: cpp_book
           path: build/cpp
-
-  test_cpp_dev:
-    name: "Test C++ Cookbook on Arrow Nightlies"
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-      - uses: actions/checkout@v1
-      - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          activate-environment: cookbook-cpp-dev
-          environment-file: cpp/dev.yml
-          auto-activate-base: false
-      - name: Test
-        run:
-          echo ${CONDA_PREFIX}
-      - name: Build cookbook
-        run:
-          make cpp
-      - name: Upload cpp book
-        uses: actions/upload-artifact@v1
-        with:
-          name: cpp_book
-          path: build/cpp

--- a/.github/workflows/test_java_linux_cookbook.yml
+++ b/.github/workflows/test_java_linux_cookbook.yml
@@ -37,12 +37,7 @@ jobs:
       matrix:
         python-version: [ '3.9' ]
         java-version: [ '11', '17', '18' ]
-        arrow_nightly: ['0', '1']
-        exclude:
-          - java-version: '11'
-            arrow_nightly: '1'
-          - java-version: '17'
-            arrow_nightly: '1'
+        arrow_nightly: ['0']
     env:
       ARROW_NIGHTLY: ${{ matrix.arrow_nightly }}
     steps:

--- a/.github/workflows/test_java_osx_cookbook.yml
+++ b/.github/workflows/test_java_osx_cookbook.yml
@@ -37,12 +37,7 @@ jobs:
       matrix:
         python-version: [ '3.9' ]
         java-version: [ '11', '17', '18' ]
-        arrow_nightly: ['0', '1']
-        exclude:
-          - java-version: '11'
-            arrow_nightly: '1'
-          - java-version: '17'
-            arrow_nightly: '1'
+        arrow_nightly: ['0']
     env:
       ARROW_NIGHTLY: ${{ matrix.arrow_nightly }}
     steps:

--- a/.github/workflows/test_python_cookbook.yml
+++ b/.github/workflows/test_python_cookbook.yml
@@ -43,19 +43,3 @@ jobs:
         run: make pytest
       - name: Build cookbook
         run: make py
-
-  test_py_dev:
-    name: "Test Python Cookbook on Arrow Nightlies"
-    runs-on: ubuntu-latest
-    env:
-      ARROW_NIGHTLY: 1
-    steps:
-      - uses: actions/checkout@v1
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install libcurl4-openssl-dev libssl-dev python3-pip
-      - name: Run tests
-        run: make pytest
-      - name: Build cookbook
-        run: make py

--- a/.github/workflows/test_r_cookbook.yml
+++ b/.github/workflows/test_r_cookbook.yml
@@ -49,25 +49,3 @@ jobs:
         run: make rtest
       - name: Build cookbooks
         run: make r
-
-  test_r_nightlies:
-    name: "Test R Cookbook on Arrow Nightlies"
-    runs-on: ubuntu-latest
-    env:
-      ARROW_NIGHTLY: 1
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
-      - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v2
-      - name: Install dependencies
-        run: |
-          sudo apt update
-          sudo apt install libcurl4-openssl-dev libssl-dev
-      - name: Run tests
-        run: make rtest
-      - name: Build cookbooks
-        run: make r


### PR DESCRIPTION
Currently we are running both tests against the stable and development versions of Arrow on PRs this might cause some issues if working against the current stable version. The idea is to add a stable branch in the future and deploy that one but on the meantime we should only run on CI against arrow dev on demand or as a scheduled task.