### PR TITLE
Update actions versions for GitHub and R lib actions

### DIFF
--- a/.github/workflows/deploy_cookbooks.yml
+++ b/.github/workflows/deploy_cookbooks.yml
@@ -10,11 +10,11 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup R
-        uses: r-lib/actions/setup-r@v1
+        uses: r-lib/actions/setup-r@v2
       - name: Setup pandoc
-        uses: r-lib/actions/setup-pandoc@v1
+        uses: r-lib/actions/setup-pandoc@v2
       - name: Install dependencies
         run: |
           sudo apt update
@@ -26,7 +26,7 @@ jobs:
       - name: Copy .asf.yaml
         run: cp .asf.yaml build/.asf.yaml
       - name: Upload book artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: build_book
           path: build/
@@ -38,7 +38,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Cache conda
         uses: actions/cache@v2
         env:
@@ -63,7 +63,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: cpp_book
           path: build/cpp
@@ -74,7 +74,7 @@ jobs:
     needs: [make_cookbooks, make_cpp]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: gh-pages
       - name: Prepare branch

--- a/.github/workflows/test_arrow_nightly_cookbook.yml
+++ b/.github/workflows/test_arrow_nightly_cookbook.yml
@@ -52,7 +52,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Setup environment
         uses: conda-incubator/setup-miniconda@v2
         with:
@@ -67,7 +67,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: cpp_book
           path: build/cpp
@@ -78,7 +78,7 @@ jobs:
     env:
       ARROW_NIGHTLY: 1
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/test_cpp_cookbook.yml
+++ b/.github/workflows/test_cpp_cookbook.yml
@@ -37,7 +37,7 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Cache conda
         uses: actions/cache@v2
         env:
@@ -61,7 +61,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
           name: cpp_book
           path: build/cpp

--- a/.github/workflows/test_python_cookbook.yml
+++ b/.github/workflows/test_python_cookbook.yml
@@ -34,7 +34,7 @@ jobs:
     name: "Test Python Cookbook on Arrow stable"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
I think the last deploy failed due to an old `setup-r` action version.
This PR updates the following actions versions:
- `checkout@v3`
- `setup-r@v2`
- `setup-pandoc@v2`
- `upload-artifact@v3`