### PR TITLE
[Dev] Configure merge to only allow Squash and merge

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -16,6 +16,10 @@
 # under the License.
 
 github:
+  enabled_merge_buttons:
+    merge: false
+    rebase: false
+    squash: true
   features:
     issues: true
   protected_branches:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,6 +30,7 @@ github:
 
 notifications:
   commits:      commits@arrow.apache.org
+  issues_status: issues@arrow.apache.org
   issues:       github@arrow.apache.org
   pullrequests: github@arrow.apache.org
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,8 @@ how to make your recipes testable.
 All participation in the Apache Arrow project is governed by the Apache
 Software Foundation’s [code of
 conduct](https://www.apache.org/foundation/policies/conduct.html).
+
+## Merging Pull Requests
+
+We use the GitHub UI to merge Pull Requests instead of a script as we do on the
+main Arrow repository. The repo is configured to use `Squash and merge`.


### PR DESCRIPTION
I did not find any documentation on how we merge on the Cookbooks. I thought it might be worth to add a note for committers.
I've also configured the repo to only allow `Squash and merge` to be consistent.
As reference this is the same configuration as arrow/adbc: https://github.com/apache/arrow-adbc/blob/main/.asf.yaml#L19-L22
I've also added the notification on opened and closed issues to the issues ML as we have for other repos.