### PR TITLE
Add Matomo Analytics to cookbook

### DIFF
--- a/build/index.html
+++ b/build/index.html
@@ -28,6 +28,24 @@
 				width: 100%;
 			}
 		</style>
+		<!-- Matomo -->
+		<script>
+			var _paq = window._paq = window._paq || [];
+			/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+			/* We explicitly disable cookie tracking to avoid privacy issues */
+			_paq.push(['disableCookies']);
+			_paq.push(['trackPageView']);
+			_paq.push(['enableLinkTracking']);
+			(function() {
+				var u="https://analytics.apache.org/";
+				_paq.push(['setTrackerUrl', u+'matomo.php']);
+				_paq.push(['setSiteId', '20']);
+				var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+				g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+			})();
+		</script>
+		<!-- End Matomo Code -->
+		
 	</head>
 	<body>
 		<div id="logo"><img src="arrow.png"/></div>

--- a/cpp/source/_templates/layout.html
+++ b/cpp/source/_templates/layout.html
@@ -2,22 +2,5 @@
 {# Use Matomo #}
 {% block extrahead %}
   {{ super() }}
-
-  <!-- Matomo -->
-  <script>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    /* We explicitly disable cookie tracking to avoid privacy issues */
-    _paq.push(['disableCookies']);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="https://analytics.apache.org/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '20']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
+  {%- include "../../../matomo.html" %}
 {% endblock %}

--- a/cpp/source/_templates/layout.html
+++ b/cpp/source/_templates/layout.html
@@ -1,0 +1,23 @@
+{% extends "!layout.html" %}
+{# Use Matomo #}
+{% block extrahead %}
+  {{ super() }}
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    /* We explicitly disable cookie tracking to avoid privacy issues */
+    _paq.push(['disableCookies']);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '20']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+{% endblock %}

--- a/java/source/_templates/layout.html
+++ b/java/source/_templates/layout.html
@@ -2,22 +2,5 @@
 {# Use Matomo #}
 {% block extrahead %}
   {{ super() }}
-
-  <!-- Matomo -->
-  <script>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    /* We explicitly disable cookie tracking to avoid privacy issues */
-    _paq.push(['disableCookies']);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="https://analytics.apache.org/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '20']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
+  {%- include "../../../matomo.html" %}
 {% endblock %}

--- a/java/source/_templates/layout.html
+++ b/java/source/_templates/layout.html
@@ -1,0 +1,23 @@
+{% extends "!layout.html" %}
+{# Use Matomo #}
+{% block extrahead %}
+  {{ super() }}
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    /* We explicitly disable cookie tracking to avoid privacy issues */
+    _paq.push(['disableCookies']);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '20']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+{% endblock %}

--- a/matomo.html
+++ b/matomo.html
@@ -1,0 +1,17 @@
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    /* We explicitly disable cookie tracking to avoid privacy issues */
+    _paq.push(['disableCookies']);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '20']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->

--- a/python/source/_templates/layout.html
+++ b/python/source/_templates/layout.html
@@ -2,22 +2,5 @@
 {# Use Matomo #}
 {% block extrahead %}
   {{ super() }}
-
-  <!-- Matomo -->
-  <script>
-    var _paq = window._paq = window._paq || [];
-    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-    /* We explicitly disable cookie tracking to avoid privacy issues */
-    _paq.push(['disableCookies']);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-    (function() {
-      var u="https://analytics.apache.org/";
-      _paq.push(['setTrackerUrl', u+'matomo.php']);
-      _paq.push(['setSiteId', '20']);
-      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-    })();
-  </script>
-  <!-- End Matomo Code -->
+  {%- include "../../../matomo.html" %}
 {% endblock %}

--- a/python/source/_templates/layout.html
+++ b/python/source/_templates/layout.html
@@ -1,0 +1,23 @@
+{% extends "!layout.html" %}
+{# Use Matomo #}
+{% block extrahead %}
+  {{ super() }}
+
+  <!-- Matomo -->
+  <script>
+    var _paq = window._paq = window._paq || [];
+    /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+    /* We explicitly disable cookie tracking to avoid privacy issues */
+    _paq.push(['disableCookies']);
+    _paq.push(['trackPageView']);
+    _paq.push(['enableLinkTracking']);
+    (function() {
+      var u="https://analytics.apache.org/";
+      _paq.push(['setTrackerUrl', u+'matomo.php']);
+      _paq.push(['setSiteId', '20']);
+      var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+      g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+    })();
+  </script>
+  <!-- End Matomo Code -->
+{% endblock %}

--- a/r/content/_bookdown.yml
+++ b/r/content/_bookdown.yml
@@ -37,21 +37,4 @@ rmd_files: [
 output:
   bookdown::gitbook:
     includes:
-      in_header: |
-        <!-- Matomo -->
-        <script>
-          var _paq = window._paq = window._paq || [];
-          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-          /* We explicitly disable cookie tracking to avoid privacy issues */
-          _paq.push(['disableCookies']);
-          _paq.push(['trackPageView']);
-          _paq.push(['enableLinkTracking']);
-          (function() {
-            var u="https://analytics.apache.org/";
-            _paq.push(['setTrackerUrl', u+'matomo.php']);
-            _paq.push(['setSiteId', '20']);
-            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
-            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
-          })();
-        </script>
-        <!-- End Matomo Code -->
+      in_header: ../../matomo.html

--- a/r/content/_bookdown.yml
+++ b/r/content/_bookdown.yml
@@ -33,3 +33,25 @@ rmd_files: [
   "python.Rmd",
   "flight.Rmd"
 ]
+
+output:
+  bookdown::gitbook:
+    includes:
+      in_header: |
+        <!-- Matomo -->
+        <script>
+          var _paq = window._paq = window._paq || [];
+          /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+          /* We explicitly disable cookie tracking to avoid privacy issues */
+          _paq.push(['disableCookies']);
+          _paq.push(['trackPageView']);
+          _paq.push(['enableLinkTracking']);
+          (function() {
+            var u="https://analytics.apache.org/";
+            _paq.push(['setTrackerUrl', u+'matomo.php']);
+            _paq.push(['setSiteId', '20']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
+          })();
+        </script>
+        <!-- End Matomo Code -->


### PR DESCRIPTION
Similar to what we did for the main arrow docs in https://github.com/apache/arrow/pull/13096. 

I tested it locally for the python version (and setup is exactly the same for cpp and java, all identical sphinx sites). ~I am not sure what the equivalent would be for R (since we are using bookdown and not pkgdown as for the main arrow docs, and I don't directly see the same option in bookdown)~ I have added it to R bookdown as well (based on how we did it for the main docs), but haven't tested this myself.