### PR TITLE
ci: update java testing to support run with python 3.9 version

### DIFF
--- a/java/ext/javadoctest.py
+++ b/java/ext/javadoctest.py
@@ -18,7 +18,7 @@ import os
 import pathlib
 import subprocess
 
-from sphinx.ext.doctest import (Any, Dict, DocTestBuilder, TestcodeDirective,
+from sphinx.ext.doctest import (Any, DocTestBuilder, TestcodeDirective,
                                 TestoutputDirective, doctest, sphinx)
 from sphinx.locale import __
 
@@ -99,7 +99,7 @@ class JavaDocTestBuilder(DocTestBuilder):
         output = (4*' ').join(output.split('\t'))
         return output
 
-def setup(app) -> Dict[str, Any]:
+def setup(app) -> dict[str, Any]:
     app.add_directive("testcode", JavaTestcodeDirective)
     app.add_directive("testoutput", TestoutputDirective)
     app.add_builder(JavaDocTestBuilder)


### PR DESCRIPTION
To close #290 