### PR TITLE
[Java] Document how to convert JDBC Adapter result into a Parquet file

### DIFF
--- a/java/source/dataset.rst
+++ b/java/source/dataset.rst
@@ -534,3 +534,9 @@ Let's read a CSV file.
    Total batch size: 3
 
 .. _Arrow Java Dataset: https://arrow.apache.org/docs/dev/java/dataset.html
+
+
+Write Parquet Files
+===================
+
+Go to :doc:`JDBC Adapter - Write ResultSet to Parquet File <jdbc>` for an example.

--- a/java/source/flight.rst
+++ b/java/source/flight.rst
@@ -287,7 +287,7 @@ Flight Client and Server
    S1: Server (Location): Listening on port 33333
    C1: Client (Location): Connected to grpc+tcp://0.0.0.0:33333
    C2: Client (Populate Data): Wrote 2 batches with 3 rows each
-   C3: Client (Get Metadata): FlightInfo{schema=Schema<name: Utf8>, descriptor=profiles, endpoints=[FlightEndpoint{locations=[Location{uri=grpc+tcp://0.0.0.0:33333}], ticket=org.apache.arrow.flight.Ticket@58871b0a}], bytes=-1, records=6, ordered=false}
+   C3: Client (Get Metadata): FlightInfo{schema=Schema<name: Utf8>, descriptor=profiles, endpoints=[FlightEndpoint{locations=[Location{uri=grpc+tcp://0.0.0.0:33333}], ticket=org.apache.arrow.flight.Ticket@58871b0a, expirationTime=(none)}], bytes=-1, records=6, ordered=false}
    C4: Client (Get Stream):
    Client Received batch #1, Data:
    name
@@ -299,7 +299,7 @@ Flight Client and Server
    Manuel
    Felipe
    JJ
-   C5: Client (List Flights Info): FlightInfo{schema=Schema<name: Utf8>, descriptor=profiles, endpoints=[FlightEndpoint{locations=[Location{uri=grpc+tcp://0.0.0.0:33333}], ticket=org.apache.arrow.flight.Ticket@58871b0a}], bytes=-1, records=6, ordered=false}
+   C5: Client (List Flights Info): FlightInfo{schema=Schema<name: Utf8>, descriptor=profiles, endpoints=[FlightEndpoint{locations=[Location{uri=grpc+tcp://0.0.0.0:33333}], ticket=org.apache.arrow.flight.Ticket@58871b0a, expirationTime=(none)}], bytes=-1, records=6, ordered=false}
    C6: Client (Do Delete Action): Delete completed
    C7: Client (List Flights Info): After delete - No records
    C8: Server shut down successfully

--- a/java/source/jdbc.rst
+++ b/java/source/jdbc.rst
@@ -307,3 +307,167 @@ values to the given scale.
    102    true    100000000030.0000000    some char text      [1,2]
    INT_FIELD1    BOOL_FIELD2    BIGINT_FIELD5    CHAR_FIELD16    LIST_FIELD19
    103    true    10000000003.0000000    some char text      [1]
+
+Write ResultSet to Parquet File
+===============================
+
+In this example, we have the JDBC adapter result and trying to write them
+into a parquet file.
+
+.. testcode::
+
+    import java.io.BufferedReader;
+    import java.io.FileReader;
+    import java.io.IOException;
+    import java.nio.file.DirectoryStream;
+    import java.nio.file.Files;
+    import java.nio.file.Path;
+    import java.sql.Connection;
+    import java.sql.DriverManager;
+    import java.sql.ResultSet;
+    import java.sql.SQLException;
+    import java.sql.Types;
+    import java.util.HashMap;
+
+    import org.apache.arrow.adapter.jdbc.ArrowVectorIterator;
+    import org.apache.arrow.adapter.jdbc.JdbcFieldInfo;
+    import org.apache.arrow.adapter.jdbc.JdbcToArrow;
+    import org.apache.arrow.adapter.jdbc.JdbcToArrowConfig;
+    import org.apache.arrow.adapter.jdbc.JdbcToArrowConfigBuilder;
+    import org.apache.arrow.adapter.jdbc.JdbcToArrowUtils;
+    import org.apache.arrow.dataset.file.DatasetFileWriter;
+    import org.apache.arrow.dataset.file.FileFormat;
+    import org.apache.arrow.dataset.file.FileSystemDatasetFactory;
+    import org.apache.arrow.dataset.jni.NativeMemoryPool;
+    import org.apache.arrow.dataset.scanner.ScanOptions;
+    import org.apache.arrow.dataset.scanner.Scanner;
+    import org.apache.arrow.dataset.source.Dataset;
+    import org.apache.arrow.dataset.source.DatasetFactory;
+    import org.apache.arrow.memory.BufferAllocator;
+    import org.apache.arrow.memory.RootAllocator;
+    import org.apache.arrow.vector.VectorLoader;
+    import org.apache.arrow.vector.VectorSchemaRoot;
+    import org.apache.arrow.vector.VectorUnloader;
+    import org.apache.arrow.vector.ipc.ArrowReader;
+    import org.apache.arrow.vector.ipc.message.ArrowRecordBatch;
+    import org.apache.arrow.vector.types.pojo.Schema;
+    import org.apache.ibatis.jdbc.ScriptRunner;
+
+    class JDBCReader extends ArrowReader {
+      private final ArrowVectorIterator iter;
+      private final Schema schema;
+
+      public JDBCReader(BufferAllocator allocator, ArrowVectorIterator iter, Schema schema) {
+        super(allocator);
+        this.iter = iter;
+        this.schema = schema;
+      }
+
+      @Override
+      public boolean loadNextBatch() throws IOException {
+        while (iter.hasNext()) {
+          try (VectorSchemaRoot rootTmp = iter.next()) {
+            if (rootTmp.getRowCount() > 0) {
+              VectorUnloader unloader = new VectorUnloader(rootTmp);
+              VectorLoader loader = new VectorLoader(super.getVectorSchemaRoot());
+              try (ArrowRecordBatch recordBatch = unloader.getRecordBatch()) {
+                loader.load(recordBatch);
+              }
+              return true;
+            }
+            else {
+              return false;
+            }
+          }
+        }
+        return false;
+      }
+
+      @Override
+      public long bytesRead() {
+        return 0;
+      }
+
+      @Override
+      protected void closeReadSource() throws IOException {
+      }
+
+      @Override
+      protected Schema readSchema() {
+        return schema;
+      }
+    }
+    final BufferAllocator allocator = new RootAllocator();
+    try (
+        final Connection connection = DriverManager.getConnection(
+            "jdbc:h2:mem:h2-jdbc-adapter")
+    ) {
+      ScriptRunner runnerDDLDML = new ScriptRunner(connection);
+      runnerDDLDML.setLogWriter(null);
+      runnerDDLDML.runScript(new BufferedReader(
+          new FileReader("./thirdpartydeps/jdbc/h2-ddl.sql")));
+      runnerDDLDML.runScript(new BufferedReader(
+          new FileReader("./thirdpartydeps/jdbc/h2-dml.sql")));
+      JdbcToArrowConfig config = new JdbcToArrowConfigBuilder(allocator,
+          JdbcToArrowUtils.getUtcCalendar())
+          .setTargetBatchSize(2)
+          .setArraySubTypeByColumnNameMap(
+              new HashMap() {{
+                put("LIST_FIELD19",
+                    new JdbcFieldInfo(Types.INTEGER));
+              }}
+          )
+          .build();
+      String query = "SELECT int_field1, bool_field2, bigint_field5, char_field16, list_field19 FROM TABLE1";
+      try (
+          final ResultSet resultSetConvertToParquet = connection.createStatement().executeQuery(query);
+          final ResultSet resultSetForSchema = connection.createStatement().executeQuery(query);
+          final ArrowVectorIterator arrowVectorIterator = JdbcToArrow.sqlToArrowVectorIterator(
+              resultSetConvertToParquet, config)
+      ) {
+        Schema schema = JdbcToArrow.sqlToArrowVectorIterator(resultSetForSchema, config).next().getSchema();
+        Path uri = Files.createTempDirectory("parquet_");
+        try (
+            // get jdbc row data as a arrow reader
+            final JDBCReader arrowReader = new JDBCReader(allocator, arrowVectorIterator, schema)
+        ) {
+          // write arrow reader to parqueet file
+          DatasetFileWriter.write(allocator, arrowReader, FileFormat.PARQUET, uri.toUri().toString());
+        }
+        // validate data of parquet file created
+        ScanOptions options = new ScanOptions(/*batchSize*/ 32768);
+        try (
+            DatasetFactory datasetFactory = new FileSystemDatasetFactory(allocator,
+                NativeMemoryPool.getDefault(), FileFormat.PARQUET, uri.toUri().toString());
+            Dataset dataset = datasetFactory.finish();
+            Scanner scanner = dataset.newScan(options);
+            ArrowReader reader = scanner.scanBatches()
+        ) {
+          while (reader.loadNextBatch()) {
+            System.out.print(reader.getVectorSchemaRoot().contentToTSVString());
+          }
+        } catch (Exception e) {
+          e.printStackTrace();
+          throw new RuntimeException(e);
+        }
+        // delete temporary parquet file created
+        try (DirectoryStream<Path> dir = Files.newDirectoryStream(uri)) {
+          uri.toFile().deleteOnExit();
+          for (Path path : dir) {
+            path.toFile().deleteOnExit();
+          }
+        }
+      }
+      runnerDDLDML.closeConnection();
+    } catch (SQLException | IOException e) {
+      e.printStackTrace();
+      throw new RuntimeException(e);
+    }
+
+.. testoutput::
+
+   INT_FIELD1    BOOL_FIELD2    BIGINT_FIELD5    CHAR_FIELD16    LIST_FIELD19
+   101    true    1000000000300    some char text      [1,2,3]
+   102    true    100000000030    some char text      [1,2]
+   INT_FIELD1    BOOL_FIELD2    BIGINT_FIELD5    CHAR_FIELD16    LIST_FIELD19
+   103    true    10000000003    some char text      [1]


### PR DESCRIPTION
In this example, we have the JDBC adapter result and trying to write them into a parquet file.

Current workaround:
- Just put Allocator creation out of try-with-resources intentionally. Reviewing how to create/release allocator properly
- If put Allocator creation inside try-with-resources errors appear such as: `Closed with outstanding buffers allocated` / `RefCnt has gone negative`