### PR TITLE
[Release] Update wrong arrow and pyarrow versions to 14.0.0

### DIFF
--- a/cpp/environment.yml
+++ b/cpp/environment.yml
@@ -20,10 +20,10 @@ channels:
 dependencies:
   - python=3.9
   - compilers
-  - arrow-cpp==12.0.0
+  - arrow-cpp==14.0.0
   - sphinx
   - gtest
   - gmock
-  - pyarrow==12.0.0
+  - pyarrow==14.0.0
   - clang-tools
   - zlib

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx>=4.0.2
-pyarrow==12.0.0
+pyarrow==14.0.0
 pandas>=1.2.5
 opentelemetry-api>=1.0.0
 opentelemetry-sdk>=1.0.0


### PR DESCRIPTION
We did not update the cookbooks from 12.0.0 to 13.0.0 and when updating from 12.0.0 to 14.0.0 the script missed the following version updates because I used:
`./dev/release/01-bump-versions.sh 13.0.0 14.0.0` instead of `./dev/release/01-bump-versions.sh 12.0.0 14.0.0`
Manually update the missing updates to run cookbooks consistently for 14.0.0.

This commit will have to be cherry-picked to the `stable` branch once merged.