### PR TITLE
MINOR: [C++][Python][Java] Add "All Cookbooks" link to each cookbook sidebar

### DIFF
--- a/cpp/source/conf.py
+++ b/cpp/source/conf.py
@@ -72,7 +72,8 @@ html_theme_options = {
     "github_type": "none",
     "extra_nav_links": {
         "User Guide": "https://arrow.apache.org/docs/cpp/index.html",
-        "API Reference": "https://arrow.apache.org/docs/cpp/api.html"
+        "API Reference": "https://arrow.apache.org/docs/cpp/api.html",
+        "All Cookbooks": "../"
     },
     "font_family": "-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,Liberation Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji"
 }

--- a/java/source/conf.py
+++ b/java/source/conf.py
@@ -79,7 +79,8 @@ html_theme_options = {
     "github_type": "none",
     "extra_nav_links": {
         "User Guide": "https://arrow.apache.org/docs/java/index.html",
-        "API Reference": "https://arrow.apache.org/docs/java/reference/index.html"
+        "API Reference": "https://arrow.apache.org/docs/java/reference/index.html",
+        "All Cookbooks": "../"
     },
     "font_family": "-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,Liberation Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji"
 }

--- a/python/source/conf.py
+++ b/python/source/conf.py
@@ -75,7 +75,8 @@ html_theme_options = {
     "github_type": "none",
     "extra_nav_links": {
         "User Guide": "https://arrow.apache.org/docs/python/index.html",
-        "API Reference": "https://arrow.apache.org/docs/python/api.html"
+        "API Reference": "https://arrow.apache.org/docs/python/api.html",
+        "All Cookbooks": "../"
     },
     "font_family": "-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Arial,Noto Sans,Liberation Sans,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol,Noto Color Emoji"
 }


### PR DESCRIPTION
While looking at the cookbooks I noticed the user doesn't have any way to navigate from an individual cookbook back up to the list of cookbooks. Part or all of the reason for this is probably that, at the source code level, each cookbook is managed as a separate Sphinx build. It's a minor thing, but this PR adds an "All Cookbooks" link below the User Guide and API Reference links in the sidebar to each cookbook.

Before:

![image](https://github.com/apache/arrow-cookbook/assets/563/ffba3845-8d14-4d04-ba3c-1976287f12e7)

After:

![image](https://github.com/apache/arrow-cookbook/assets/563/0df78023-f6bb-4726-b695-f494de490319)

I opted to use a relative link instead of an absolute one so the link works locally and on preview builds but let me know if that should be changed.