### PR TITLE
[PYTHON] Add a recipe for sending mixed schema data over a single Flight stream

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,5 +1,5 @@
 Sphinx>=4.0.2
-pyarrow==15.0.2
+pyarrow==16.1.0
 pandas>=1.2.5
 opentelemetry-api>=1.0.0
 opentelemetry-sdk>=1.0.0


### PR DESCRIPTION

Recently there was a [question](https://lists.apache.org/thread/xwxskb7mnfsc6qsoxgsk2yr38shyxrvw) on the Arrow Users mailing list about how to send tables or record batches with multiple schemas over a single Flight stream. @lidavidm provided a helpful answer and mentioned that this question had come up in discussion [previously](https://lists.apache.org/thread/5lzxx5onmvq9w7vdrnxjt3vt4t66dczz). I thought the suggested solution would be a good addition to the cookbook since the idea of using a union of struct types may not be entirely obvious to newcomers to Flight and the problem itself is one that multiple people have run into (including me :-)

Anyway here's my attempt at a recipe. Any feedback gratefully appreciated.