### PR TITLE
MINOR: Bump `actions/*-artifact` to v4 and enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "MINOR: "
+

--- a/.github/workflows/deploy_development_cookbooks.yml
+++ b/.github/workflows/deploy_development_cookbooks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build and render books
         run: make all
       - name: Upload book artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_book
           path: build/
@@ -69,7 +69,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp_book
           path: build/cpp
@@ -89,12 +89,12 @@ jobs:
           git rm -rf --ignore-unmatch ./dev
           mkdir dev
       - name: Download book artifact
-        uses: actions/download-artifact@v1.0.0
+        uses: actions/download-artifact@v4.0.0
         with:
           name: build_book
           path: ./dev
       - name: Download cpp book
-        uses: actions/download-artifact@v1.0.0
+        uses: actions/download-artifact@v4.0.0
         with:
           name: cpp_book
           path: ./dev/cpp

--- a/.github/workflows/deploy_development_cookbooks.yml
+++ b/.github/workflows/deploy_development_cookbooks.yml
@@ -89,12 +89,12 @@ jobs:
           git rm -rf --ignore-unmatch ./dev
           mkdir dev
       - name: Download book artifact
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v4
         with:
           name: build_book
           path: ./dev
       - name: Download cpp book
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v4
         with:
           name: cpp_book
           path: ./dev/cpp

--- a/.github/workflows/deploy_stable_cookbooks.yml
+++ b/.github/workflows/deploy_stable_cookbooks.yml
@@ -93,12 +93,12 @@ jobs:
           git rm -rf .
           cp -R ../dev .
       - name: Download book artifact
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v4
         with:
           name: build_book
           path: ./cookbook
       - name: Download cpp book
-        uses: actions/download-artifact@v4.0.0
+        uses: actions/download-artifact@v4
         with:
           name: cpp_book
           path: ./cookbook/cpp

--- a/.github/workflows/deploy_stable_cookbooks.yml
+++ b/.github/workflows/deploy_stable_cookbooks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Copy .asf.yaml
         run: cp .asf.yaml build/.asf.yaml
       - name: Upload book artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build_book
           path: build/
@@ -69,7 +69,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp_book
           path: build/cpp
@@ -93,12 +93,12 @@ jobs:
           git rm -rf .
           cp -R ../dev .
       - name: Download book artifact
-        uses: actions/download-artifact@v1.0.0
+        uses: actions/download-artifact@v4.0.0
         with:
           name: build_book
           path: ./cookbook
       - name: Download cpp book
-        uses: actions/download-artifact@v1.0.0
+        uses: actions/download-artifact@v4.0.0
         with:
           name: cpp_book
           path: ./cookbook/cpp

--- a/.github/workflows/test_arrow_nightly_cookbook.yml
+++ b/.github/workflows/test_arrow_nightly_cookbook.yml
@@ -67,7 +67,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp_book
           path: build/cpp

--- a/.github/workflows/test_cpp_cookbook.yml
+++ b/.github/workflows/test_cpp_cookbook.yml
@@ -62,7 +62,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cpp_book
           path: build/cpp


### PR DESCRIPTION
The artifact actions of <v3 will be removed soon. To avoid PR spam but also keep actions decently up-to-date I have added a dependabot.yml.