### PR TITLE
GH-363: [Java] Run maven in batch mode

### DIFF
--- a/java/ext/javadoctest.py
+++ b/java/ext/javadoctest.py
@@ -86,6 +86,7 @@ class JavaDocTestBuilder(DocTestBuilder):
             test_proc = subprocess.Popen(
                 [
                     "mvn",
+                    "--batch-mode",
                     "-f",
                     project_dir,
                     "compile",


### PR DESCRIPTION
Without --batch-mode, we can sometimes get ANSI escape sequences in the input which makes downstream processing more complicated.

Fixes #363 