### PR TITLE
MINOR: Fix branch protection in .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,8 +23,7 @@ github:
   features:
     issues: true
   protected_branches:
-    main:
-      foo: bar # dummy value to make main a dictionary
+    main: {}
   ghp_branch:  gh-pages
   ghp_path:    .
 


### PR DESCRIPTION
The `.asf.yaml` has been processed by a new, stricter system but we didn't have any changes since it was activated, so the issue with the dummy key didn't show up. I was informed through an email notification of this issue.

I have not opened this as a fork PR to enable the notification via email in case there is still an issue.