### PR TITLE
GH-381: [R] Use RETICULATE_PYTHON="managed" in test.R

### DIFF
--- a/r/scripts/test.R
+++ b/r/scripts/test.R
@@ -55,5 +55,9 @@ dir.create(td)
 # Extract R code from files
 purrr::walk(files, extract_r_code, dir = td)
 
+# Fixes CI for newer reticulate by forcing reticulate to manage itself even if
+# it finds other Python installations on the host
+Sys.setenv(RETICULATE_PYTHON="managed")
+
 # Run tests
 testthat::test_dir(path = td)


### PR DESCRIPTION
I'm somewhat confident this will fix the CI issue on the stable branch we're seeing in https://github.com/apache/arrow-cookbook/issues/381.

I did some testing on draft PRs. 