### PR TITLE
MINOR: Bump action versions to latest, pin unofficial ones

### DIFF
--- a/.github/workflows/deploy_development_cookbooks.yml
+++ b/.github/workflows/deploy_development_cookbooks.yml
@@ -15,7 +15,7 @@ jobs:
     env:
       ARROW_NIGHTLY: 1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -35,7 +35,7 @@ jobs:
       - name: Build and render books
         run: make all
       - name: Upload book artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: build_book
           path: build/
@@ -47,9 +47,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Cache conda
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           # Increase this value to reset cache if cpp/dev.yml has not changed
           CACHE_NUMBER: 0
@@ -58,7 +58,7 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('cpp/dev.yml') }}
       - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           auto-update-conda: true
           python-version: "3.10"
@@ -74,7 +74,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cpp_book
           path: build/cpp
@@ -86,7 +86,7 @@ jobs:
     if: github.event_name == 'push'
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
       - name: Prepare branch
@@ -95,12 +95,12 @@ jobs:
           git rm -rf --ignore-unmatch ./dev
           mkdir dev
       - name: Download book artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build_book
           path: ./dev
       - name: Download cpp book
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: cpp_book
           path: ./dev/cpp

--- a/.github/workflows/deploy_stable_cookbooks.yml
+++ b/.github/workflows/deploy_stable_cookbooks.yml
@@ -10,7 +10,7 @@ jobs:
     name: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -32,7 +32,7 @@ jobs:
       - name: Copy .asf.yaml
         run: cp .asf.yaml build/.asf.yaml
       - name: Upload book artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: build_book
           path: build/
@@ -44,9 +44,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Cache conda
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           # Increase this value to reset cache if cpp/environment.yml has not changed
           CACHE_NUMBER: 0
@@ -55,7 +55,7 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('cpp/environment.yml') }}
       - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           auto-update-conda: true
           python-version: "3.10"
@@ -69,7 +69,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cpp_book
           path: build/cpp
@@ -80,7 +80,7 @@ jobs:
     needs: [make_stable_cookbooks, make_stable_cpp]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
           path: cookbook
@@ -93,12 +93,12 @@ jobs:
           git rm -rf .
           cp -R ../dev .
       - name: Download book artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: build_book
           path: ./cookbook
       - name: Download cpp book
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           name: cpp_book
           path: ./cookbook/cpp

--- a/.github/workflows/test_arrow_nightly_cookbook.yml
+++ b/.github/workflows/test_arrow_nightly_cookbook.yml
@@ -29,7 +29,7 @@ jobs:
     env:
       ARROW_NIGHTLY: 1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:
@@ -54,9 +54,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           auto-update-conda: true
           activate-environment: cookbook-cpp-dev
@@ -69,7 +69,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cpp_book
           path: build/cpp
@@ -80,7 +80,7 @@ jobs:
     env:
       ARROW_NIGHTLY: 1
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt update
@@ -101,8 +101,8 @@ jobs:
     env:
       ARROW_NIGHTLY: ${{ matrix.arrow_nightly }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/setup-java@v5
@@ -125,8 +125,8 @@ jobs:
     env:
       ARROW_NIGHTLY: ${{ matrix.arrow_nightly }}
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/setup-java@v5

--- a/.github/workflows/test_cpp_cookbook.yml
+++ b/.github/workflows/test_cpp_cookbook.yml
@@ -38,9 +38,9 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Cache conda
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         env:
           # Increase this value to reset cache if cpp/conda-linux-64.lock has not changed
           CACHE_NUMBER: 0
@@ -49,7 +49,7 @@ jobs:
           key:
             ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('cpp/conda-linux-64.lock') }}
       - name: Setup stable environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           auto-update-conda: true
           activate-environment: cookbook-cpp
@@ -62,7 +62,7 @@ jobs:
         run:
           make cpp
       - name: Upload cpp book
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: cpp_book
           path: build/cpp

--- a/.github/workflows/test_java_cookbook.yml
+++ b/.github/workflows/test_java_cookbook.yml
@@ -41,8 +41,8 @@ jobs:
         python-version: [ '3.10' ]
         java-version: [ '11', '17', '18' ]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/setup-java@v5
@@ -70,8 +70,8 @@ jobs:
         python-version: [ '3.10' ]
         java-version: [ '11', '17', '18' ]
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - uses: actions/setup-java@v5

--- a/.github/workflows/test_python_cookbook.yml
+++ b/.github/workflows/test_python_cookbook.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       ARROW_NIGHTLY: ${{ github.base_ref == 'main' && 1 || 0 }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt update

--- a/.github/workflows/test_r_cookbook.yml
+++ b/.github/workflows/test_r_cookbook.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       ARROW_NIGHTLY: ${{ github.base_ref == 'main' && 1 || 0 }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Setup R
         uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
Bump GHA versions repo wide, using floating tags for "official" actions and pinning to SHAs for unofficial ones.